### PR TITLE
Check response codes in order/kitchen service clients

### DIFF
--- a/app/services/kitchen/pkg/clients/ordersclient/errors.go
+++ b/app/services/kitchen/pkg/clients/ordersclient/errors.go
@@ -1,0 +1,5 @@
+package ordersclient
+
+import "errors"
+
+var ErrOrderServiceFailed = errors.New("http request to order service resulted in error")

--- a/app/services/kitchen/pkg/clients/ordersclient/ordersclient.go
+++ b/app/services/kitchen/pkg/clients/ordersclient/ordersclient.go
@@ -41,6 +41,10 @@ func (c OrdersClient) GetIncompleteOrders(id int) (*orderapi.ReturnOrderList, er
 		return nil, fmt.Errorf("sending HTTP request: %w", err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: http status: %d", ErrOrderServiceFailed, resp.StatusCode)
+	}
+
 	orders := new(orderapi.ReturnOrderList)
 
 	err = v1.DecodeResponse(resp, orders)

--- a/app/services/order/pkg/clients/restaurantclient/errors.go
+++ b/app/services/order/pkg/clients/restaurantclient/errors.go
@@ -1,0 +1,5 @@
+package restaurantclient
+
+import "errors"
+
+var ErrRestaurantFail = errors.New("http request to restaurant service resulted in error")

--- a/app/services/order/pkg/clients/restaurantclient/restaurantclient.go
+++ b/app/services/order/pkg/clients/restaurantclient/restaurantclient.go
@@ -24,6 +24,10 @@ func (r RestaurantClient) CheckIfAvailable(restaurantID int) (bool, error) {
 		return false, fmt.Errorf("getting restaurant: %w", err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("%w: response code %d", ErrRestaurantFail, resp.StatusCode)
+	}
+
 	restaurant := new(restaurantapi.ReturnRestaurant)
 
 	err = v1.DecodeResponse(resp, restaurant)
@@ -38,6 +42,10 @@ func (r RestaurantClient) CalculateOrderPrice(order domain.Order) (float64, erro
 	resp, err := http.Get(r.restaurantURL + "/v1/restaurants/" + strconv.Itoa(order.RestaurantID) + "/menu")
 	if err != nil {
 		return 0, fmt.Errorf("getting menu: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("%w: response code %d", ErrRestaurantFail, resp.StatusCode)
 	}
 
 	menu := new(restaurantapi.ReturnMenu)


### PR DESCRIPTION
Clients in order and kitchen services now check for the http status code to ensure that everything went smoothly in the external service.